### PR TITLE
Add and document nvidia blacklist boot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ starting the installation.
 One should not generally install software when booting as a live disk.
 The "use 25% of RAM as root fs space" option is for those who know what they're
 doing.
+
+Boot options blacklisting the nvidia* modules: should be useful for older nvidia cards unsupported by the latest drivers.

--- a/releng/efiboot/loader/entries/05-archiso-x86_64-no-nvidia-module.conf
+++ b/releng/efiboot/loader/entries/05-archiso-x86_64-no-nvidia-module.conf
@@ -1,0 +1,6 @@
+title   Arch Linux install medium (x86_64, UEFI, old nvidia cards)
+linux   /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
+initrd  /%INSTALL_DIR%/boot/intel-ucode.img
+initrd  /%INSTALL_DIR%/boot/amd-ucode.img
+initrd  /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
+options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% modprobe.blacklist=nvidia,nvidia_uvm,nvidia_drm,nvidia_modeset

--- a/releng/syslinux/archiso_sys-linux.cfg
+++ b/releng/syslinux/archiso_sys-linux.cfg
@@ -41,3 +41,13 @@ MENU LABEL Arch Linux install medium (x86_64, BIOS, Copy to RAM, cow_spacesize=2
 LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 INITRD /%INSTALL_DIR%/boot/intel-ucode.img,/%INSTALL_DIR%/boot/amd-ucode.img,/%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
 APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=25% copytoram
+
+LABEL arch64nonvidia
+TEXT HELP
+Boot the Arch Linux install medium on BIOS with the nvidia modules blacklisted.
+Should be suitable for older nvidia cards.
+ENDTEXT
+MENU LABEL Arch Linux install medium (x86_64, BIOS, old nvidia cards)
+LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
+INITRD /%INSTALL_DIR%/boot/intel-ucode.img,/%INSTALL_DIR%/boot/amd-ucode.img,/%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
+APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% modprobe.blacklist=nvidia,nvidia_uvm,nvidia_drm,nvidia_modeset


### PR DESCRIPTION
Since the latest nvidia drivers only support newer cards, provide a boot option disabling them.