### PR TITLE
Disable nouveau in most boot configs

### DIFF
--- a/releng/efiboot/loader/entries/01-archiso-x86_64-linux.conf
+++ b/releng/efiboot/loader/entries/01-archiso-x86_64-linux.conf
@@ -3,4 +3,4 @@ linux   /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 initrd  /%INSTALL_DIR%/boot/intel-ucode.img
 initrd  /%INSTALL_DIR%/boot/amd-ucode.img
 initrd  /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL%
+options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% modprobe.blacklist=nouveau

--- a/releng/efiboot/loader/entries/02-archiso-x86_64-speech-linux.conf
+++ b/releng/efiboot/loader/entries/02-archiso-x86_64-speech-linux.conf
@@ -3,4 +3,4 @@ linux   /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 initrd  /%INSTALL_DIR%/boot/intel-ucode.img
 initrd  /%INSTALL_DIR%/boot/amd-ucode.img
 initrd  /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% accessibility=on
+options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% accessibility=on modprobe.blacklist=nouveau

--- a/releng/efiboot/loader/entries/03-archiso-x86_64-ram-linux.conf
+++ b/releng/efiboot/loader/entries/03-archiso-x86_64-ram-linux.conf
@@ -3,4 +3,4 @@ linux   /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 initrd  /%INSTALL_DIR%/boot/intel-ucode.img
 initrd  /%INSTALL_DIR%/boot/amd-ucode.img
 initrd  /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% copytoram
+options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% copytoram modprobe.blacklist=nouveau

--- a/releng/efiboot/loader/entries/04-archiso-x86_64-ram-25pc-linux.conf
+++ b/releng/efiboot/loader/entries/04-archiso-x86_64-ram-25pc-linux.conf
@@ -3,4 +3,4 @@ linux   /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 initrd  /%INSTALL_DIR%/boot/intel-ucode.img
 initrd  /%INSTALL_DIR%/boot/amd-ucode.img
 initrd  /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=25% copytoram
+options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=25% copytoram modprobe.blacklist=nouveau

--- a/releng/packages.x86_64
+++ b/releng/packages.x86_64
@@ -206,6 +206,7 @@ mpv
 mtr
 nautilus
 network-manager-applet
+nouveau
 nvidia
 nvidia-settings
 owncloud-client

--- a/releng/syslinux/archiso_sys-linux.cfg
+++ b/releng/syslinux/archiso_sys-linux.cfg
@@ -17,7 +17,7 @@ ENDTEXT
 MENU LABEL Arch Linux install medium (x86_64, BIOS) with ^speech
 LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 INITRD /%INSTALL_DIR%/boot/intel-ucode.img,/%INSTALL_DIR%/boot/amd-ucode.img,/%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% accessibility=on
+APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% accessibility=on modprobe.blacklist=nouveau
 
 # Copy to RAM boot option
 LABEL arch64ram
@@ -28,7 +28,7 @@ ENDTEXT
 MENU LABEL Arch Linux install medium (x86_64, BIOS, Copy to RAM)
 LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 INITRD /%INSTALL_DIR%/boot/intel-ucode.img,/%INSTALL_DIR%/boot/amd-ucode.img,/%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% copytoram
+APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% copytoram modprobe.blacklist=nouveau
 
 # Copy to RAM 25% cow_spacesize boot option
 LABEL arch64ram25pc
@@ -40,7 +40,7 @@ ENDTEXT
 MENU LABEL Arch Linux install medium (x86_64, BIOS, Copy to RAM, cow_spacesize=25% of RAM)
 LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 INITRD /%INSTALL_DIR%/boot/intel-ucode.img,/%INSTALL_DIR%/boot/amd-ucode.img,/%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=25% copytoram
+APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=25% copytoram modprobe.blacklist=nouveau
 
 LABEL arch64nonvidia
 TEXT HELP


### PR DESCRIPTION
A more elegant implementation might be to create sub menu entries for each of nouveau and nvidia.