### PR TITLE
Update from upstream v74

### DIFF
--- a/releng/airootfs/etc/systemd/network/20-ethernet.network
+++ b/releng/airootfs/etc/systemd/network/20-ethernet.network
@@ -5,6 +5,9 @@
 Name=en*
 Name=eth*
 
+[Link]
+RequiredForOnline=routable
+
 [Network]
 DHCP=yes
 MulticastDNS=yes

--- a/releng/airootfs/etc/systemd/network/20-wlan.network
+++ b/releng/airootfs/etc/systemd/network/20-wlan.network
@@ -1,6 +1,9 @@
 [Match]
 Name=wl*
 
+[Link]
+RequiredForOnline=routable
+
 [Network]
 DHCP=yes
 MulticastDNS=yes

--- a/releng/airootfs/etc/systemd/network/20-wwan.network
+++ b/releng/airootfs/etc/systemd/network/20-wwan.network
@@ -1,6 +1,9 @@
 [Match]
 Name=ww*
 
+[Link]
+RequiredForOnline=routable
+
 [Network]
 DHCP=yes
 IPv6PrivacyExtensions=yes

--- a/releng/airootfs/root/.automated_script.sh
+++ b/releng/airootfs/root/.automated_script.sh
@@ -16,7 +16,7 @@ automated_script() {
     local script rt
     script="$(script_cmdline)"
     if [[ -n "${script}" && ! -x /tmp/startup_script ]]; then
-        if [[ "${script}" =~ ^((http|https|ftp)://) ]]; then
+        if [[ "${script}" =~ ^((http|https|ftp|tftp)://) ]]; then
             # there's no synchronization for network availability before executing this script
             printf '%s: waiting for network-online.target\n' "$0"
             until systemctl --quiet is-active network-online.target; do

--- a/releng/packages.x86_64
+++ b/releng/packages.x86_64
@@ -4,6 +4,7 @@ arch-install-scripts
 archinstall
 b43-fwcutter
 base
+bcachefs-tools
 bind
 bolt
 brltty


### PR DESCRIPTION
(From the release)

- Add bcachefs-tools to releng for access to bcachefs userspace tools.
- Add tftp as a valid protocol for downloading automated boot script.
- Set ``RequiredForOnline=routable`` in systemd-networkd configuration files to improve the chances that the network
  really is *online* when ``network-online.target`` is reached.

See also: https://github.com/archlinux/archiso/compare/v73...v74